### PR TITLE
Fix: add single quotes to escape pwsh call operator

### DIFF
--- a/src/pages/config/index.vue
+++ b/src/pages/config/index.vue
@@ -171,9 +171,9 @@ export default {
       const prefix = "minyami";
       let command = "";
       if (!this.form.recoverMode) {
-        command += `${prefix} -d "${chunklist.url}" --output "${playlist.title}.ts"`;
+        command += `${prefix} -d '"${chunklist.url}"' --output "${playlist.title}.ts"`;
       } else {
-        command += `${prefix} -r "${chunklist.url}"`;
+        command += `${prefix} -r '"${chunklist.url}"'`;
       }
       if (this.keys.length > 0) {
         command += ` --key "${this.keys[0]}"`;


### PR DESCRIPTION
`&` is treated as a call operator in pwsh. This commit escapes it by adding single quotes `'`.
`&` may also be escaped by using three double quotes `"""` or adding `--%` in front of arguments to prevent pwsh to expand args, though which may not be fully compatible with MS Command or Linux Shell.