### PR TITLE
add support for stagecrowd archive

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,7 +38,8 @@
         "https://hibiki-radio.jp/*",
         "https://www.youtube.com/*",
         "https://nogidoga.com/episode/*",
-        "https://spwn.jp/*"
+        "https://spwn.jp/*",
+        "https://stagecrowd.live/*"
     ],
     "content_scripts": [
         {
@@ -62,7 +63,8 @@
                 "https://hibiki-radio.jp/*",
                 "https://www.youtube.com/*",
                 "https://nogidoga.com/episode/*",
-                "https://spwn.jp/*"
+                "https://spwn.jp/*",
+                "https://stagecrowd.live/*"
             ],
             "run_at": "document_end",
             "js": ["./assets/scripts/inject.js"]
@@ -90,7 +92,8 @@
             "https://hibiki-radio.jp/*",
             "https://www.youtube.com/*",
             "https://nogidoga.com/episode/*",
-            "https://spwn.jp/*"
+            "https://spwn.jp/*",
+            "https://stagecrowd.live/*"
         ]
     },
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApOAvWQj8J9VZITRyM3ZkADne+Mswjchky3CFZon98uxrUwf1yV0RFzm8Y9CkygRHgNlKlLSFQF0pi5Or6YziNJpc1z97VgmI7Wwv89R/D/92JHyw1oq+LWmQAv3NnpJNqUGqMvTWmDamLP6z1kE4ikeGvqBSvlN+vlGSCYM4shS3JyavRL4LM1rBvTyFGFXmotixJ9HVEB6+IZa9tjHWHrz5FD5WAYjCKOuj3Cw6uC0tAOKTTr2vwVVUEHGPJDNd/WXGyyIeZw6kocd459L6MM5VkV/xSvwcwvvftAj/JVH0mo6nRQn2R1L+9l6XMYMZAW2D5USCwcFu542C9B8ATwIDAQAB"

--- a/src/definitions/index.js
+++ b/src/definitions/index.js
@@ -14,5 +14,6 @@ export const supportedSites = [
     "hibiki-radio.jp",
     "www.youtube.com",
     "nogidoga.com",
-    "tif.spwn.jp"
+    "tif.spwn.jp",
+    "stagecrowd.live"
 ];


### PR DESCRIPTION
直播流因为暂时没有可以拿来尝试的源分析就没实现（LiSA的fc直播用的是stagecrowd的方案并且疑似始终是live状态，但不确定就没动手，打算下周试试看），archive用当前方案就可以直接获取，得到的是音视频分开的两条流，需要自行合并。

测试平台：Windows 10 x64 
浏览器：Chrome 87

![image.png](https://i.loli.net/2021/01/14/K3OVPNpdbfMmq9g.png)