### PR TITLE
Fix message passing on mobile

### DIFF
--- a/assets/scripts/inject_core.js
+++ b/assets/scripts/inject_core.js
@@ -8,13 +8,13 @@
     const notify =
         window.notifyMinyamiExtractor /* Firefox */ || ((msg) => chrome.runtime.sendMessage(MINYAMI_EXTENSION_ID, msg));
     window.addEventListener(
-        "MinyamiGetCachedPageUrl",
+        "MinyamiGetPageUrl",
         () => {
-            window.dispatchEvent(new CustomEvent("MinyamiCachedPageUrl", { detail: window.location.href }));
+            window.dispatchEvent(new CustomEvent("MinyamiPageUrl", { detail: window.location.href }));
         },
         false
     );
-    window.addEventListener("unload", notify({ type: "page_url", detail: window.location.href }), false);
+    window.addEventListener("unload", notify({ type: "page_url", url: window.location.href }), false);
     const escapeFilename = (filename) => {
         return filename.replace(/[\/\*\\\:|\?<>"!]/gi, "");
     };

--- a/src/messages/en.js
+++ b/src/messages/en.js
@@ -27,7 +27,7 @@ export default {
     },
     tooltip: {
         initial: "No data available",
-        waiting: "Waiting for more data...",
+        waiting: "Awaiting more data",
         ready: "Streams available",
         stopped: "Page not supported"
     }

--- a/src/pages/background/index.js
+++ b/src/pages/background/index.js
@@ -35,10 +35,16 @@ let currentExtTab;
 // 处理注入页面消息
 const handleContentScriptMessage = async (message, sender) => {
     if (!sender.tab || message.type === "chunklist") return;
-    if (message.type === "query_livedata") { // 移动端浏览器弹窗标签页
+    if (message.type === "query_livedata") { // /* 移动端浏览器弹窗标签页
         currentExtTab = sender.tab.id;
         return handleLiveDataQuery(message, sender);
     }
+    if (message.type === "save_config" || message.type === "set_language") {
+        for (const tab of await chrome.tabs.query({ url: sender.tab.url })) {
+            if (tab.id === sender.tab.id) continue;
+            chrome.tabs.sendMessage(tab.id, message);
+        }
+    }                                        // */
     const tabId = sender.tab.id;
     if (message.type === "page_url") { // window.onunload
         tabToUrl[tabId] = message.url;

--- a/src/pages/background/index.js
+++ b/src/pages/background/index.js
@@ -17,10 +17,10 @@ const getCachedTabUrl = (tabId) => new Promise((resolve) => {
         target: { tabId },
         func: () => {
             let url;
-            window.addEventListener("MinyamiCachedPageUrl", (value) => {
+            window.addEventListener("MinyamiPageUrl", (value) => {
                 url = value.detail;
             }, { capture: false, once: true });
-            window.dispatchEvent(new CustomEvent("MinyamiGetCachedPageUrl"));
+            window.dispatchEvent(new CustomEvent("MinyamiGetPageUrl"));
             return url;
         }
     }, (results) => {
@@ -30,12 +30,18 @@ const getCachedTabUrl = (tabId) => new Promise((resolve) => {
         resolve(tabToUrl[tabId]);
     });
 });
+
+let currentExtTab;
 // 处理注入页面消息
 const handleContentScriptMessage = async (message, sender) => {
     if (!sender.tab || message.type === "chunklist") return;
+    if (message.type === "query_livedata") { // 移动端浏览器弹窗标签页
+        currentExtTab = sender.tab.id;
+        return handleLiveDataQuery(message, sender);
+    }
     const tabId = sender.tab.id;
     if (message.type === "page_url") { // window.onunload
-        tabToUrl[tabId] = message.detail;
+        tabToUrl[tabId] = message.url;
         return;
     }
     const url = await getCachedTabUrl(tabId); // 必然回复可用值
@@ -74,8 +80,10 @@ const handleContentScriptMessage = async (message, sender) => {
         }
     }
     // 实时更新浮窗页面数据
-    if (sender.tab.active) {
-        chrome.runtime.sendMessage({
+    const sendMessage = sender.tab.active ? chrome.runtime.sendMessage :
+        currentExtTab && ((msg) => chrome.tabs.sendMessage(currentExtTab, msg));
+    if (sendMessage) {
+        sendMessage({
             type: "update_livedata",
             tabId,
             detail: {
@@ -93,9 +101,29 @@ chrome.runtime.onMessageExternal.addListener(handleContentScriptMessage);
 // Firefox
 chrome.runtime.onMessage.addListener(handleContentScriptMessage);
 // 处理浮窗页面消息
+const handleLiveDataQuery = async (message, sender) => {
+    // console.log(message, sender);
+    const sendMessage = sender.tab ?
+        (msg) => chrome.tabs.sendMessage(sender.tab.id, msg) : chrome.runtime.sendMessage;
+    const tab = await chrome.tabs.get(message.tabId);
+    if (!tab || urlNotSupported(tab.url)) return;
+    if (tab.status !== "loading" && !await getCachedTabUrl(tab.id)) return;
+    sendMessage({
+        type: "update_livedata",
+        tabId: tab.id,
+        detail: {
+            playlists: await getTabPlaylists(tab.id),
+            keys: await getTabKeys(tab.id),
+            cookies: await getTabCookies(tab.id),
+            currentUrl: tabToUrl[tab.id],
+            currentUrlHost: new URL(tabToUrl[tab.id]).host,
+            status: await getTabStatusFlags(tab.id)
+        }
+    });
+};
+
 chrome.runtime.onMessage.addListener(async (message, sender) => {
     if (sender.tab) return;
-    // console.log(message);
     if (message.type === "set_language") {
         for (const tab of await chrome.tabs.query({})) {
             if (!urlNotSupported(tab.url)) await getCachedTabUrl(tab.id);
@@ -103,23 +131,8 @@ chrome.runtime.onMessage.addListener(async (message, sender) => {
         }
         return;
     }
-    if (message.type === "query_livedata") { // 浮窗页面装载
-        const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-        if (!tabs || tabs.length === 0 || urlNotSupported(tabs[0].url)) return;
-        const currentTab = tabs[0].id;
-        if (tabs[0].status !== "loading" && !await getCachedTabUrl(currentTab)) return;
-        chrome.runtime.sendMessage({
-            type: "update_livedata",
-            tabId: currentTab,
-            detail: {
-                playlists: await getTabPlaylists(currentTab),
-                keys: await getTabKeys(currentTab),
-                cookies: await getTabCookies(currentTab),
-                currentUrl: tabToUrl[currentTab],
-                currentUrlHost: new URL(tabToUrl[currentTab]).host,
-                status: await getTabStatusFlags(currentTab)
-            }
-        });
+    if (message.type === "query_livedata" && message.tabId) { // 浮窗页面装载
+        await handleLiveDataQuery(message, sender);
     }
 });
 // 监视新建或刷新标签页
@@ -155,6 +168,7 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 });
 
 chrome.tabs.onRemoved.addListener(async (tabId, removeInfo) => {
+    if (tabId === currentExtTab) return currentExtTab = undefined;
     const url = tabToUrl[tabId];
     if (url) {
         await Storage.removeHistory(url);

--- a/src/pages/config/index.vue
+++ b/src/pages/config/index.vue
@@ -261,12 +261,14 @@ export default {
             await Storage.setConfig("threads", threads);
             await Storage.setConfig("useNPX", useNPX);
             this.showConfig = false;
+            if (await chrome.tabs.getCurrent()) return;
             chrome.runtime.sendMessage({ type: "save_config" });
         },
         async changeLanguage() {
             const targetLanguage = this.$i18n.locale === "en" ? "zh_CN" : "en";
             await Storage.setConfig("language", targetLanguage);
             this.$i18n.locale = targetLanguage;
+            if (await chrome.tabs.getCurrent()) return;
             chrome.runtime.sendMessage({ type: "set_language" });
         }
     }

--- a/src/pages/config/index.vue
+++ b/src/pages/config/index.vue
@@ -193,18 +193,18 @@ export default {
         this.configForm.threads = await Storage.getConfig("threads");
         this.configForm.useNPX = await Storage.getConfig("useNPX");
         const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-        if (!tabs || tabs.length === 0) return;
-        this.currentTab = tabs[0].id;
+        if (tabs.length === 0) return;
+        const tabId = this.currentTab = tabs[0].id;
         chrome.runtime.onMessage.addListener(this.handleDataUpdate);
-        chrome.runtime.sendMessage({ type: "query_livedata" });
+        chrome.runtime.sendMessage({ type: "query_livedata", tabId });
     },
     unmounted() {
         if (!this.currentTab) return;
         chrome.runtime.onMessage.removeListener(this.handleDataUpdate);
     },
     methods: {
-        async handleDataUpdate(message) {
-            // console.log(message);
+        async handleDataUpdate(message, sender) {
+            // console.log(message, sender);
             if (message.type === "set_language") {
                 this.$i18n.locale = await Storage.getConfig("language");
             }

--- a/src/pages/config/index.vue
+++ b/src/pages/config/index.vue
@@ -261,14 +261,12 @@ export default {
             await Storage.setConfig("threads", threads);
             await Storage.setConfig("useNPX", useNPX);
             this.showConfig = false;
-            if (await chrome.tabs.getCurrent()) return;
             chrome.runtime.sendMessage({ type: "save_config" });
         },
         async changeLanguage() {
             const targetLanguage = this.$i18n.locale === "en" ? "zh_CN" : "en";
             await Storage.setConfig("language", targetLanguage);
             this.$i18n.locale = targetLanguage;
-            if (await chrome.tabs.getCurrent()) return;
             chrome.runtime.sendMessage({ type: "set_language" });
         }
     }


### PR DESCRIPTION
- 修复由于` pop-up page 在移动端 Chromium 被当作独立标签页造成的信息传递失败的 regression（Kiwi Browser 测试通过，除了移动端本身正常 tabs 与 incognito tabs 无法互访造成开关扩展后不能恢复状态的问题，以及没有后台加载因而无法即时刷新而是需要切回媒体页再切回 pop-up 才会展示的差异，其他一切完美，当然桌面端也同样测试通过）
- 修改 `inject_core.js` 自定义消息的名字（既然是最新的 URL 那就不能叫 cached URL）
- 还原一处英文文案（awaiting 含 expecting 义，比 waiting for 本来更贴切，而且省略号很突兀）