### PR TITLE
Properly fix sites without need for key interception

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Minyami",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "author": "Eridanus Sora",
     "manifest_version": 3,
     "description": "Minyami Chrome Extension",

--- a/src/pages/config/index.vue
+++ b/src/pages/config/index.vue
@@ -155,8 +155,7 @@ import {
     minyamiVersionRequirementMap,
     siteAdditionalHeaders,
     siteThreadsSettings,
-    parseStatusFlags,
-    needKeySites
+    parseStatusFlags
 } from "../../definitions";
 const dataFields = ["playlists", "keys", "cookies", "currentUrl", "currentUrlHost", "status"];
 export default {
@@ -198,7 +197,7 @@ export default {
         this.configForm.useNPX = await Storage.getConfig("useNPX");
         const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
         if (tabs.length === 0) return;
-        const tabId = (this.currentTab = tabs[0].id);
+        const tabId = this.currentTab = tabs[0].id;
         chrome.runtime.onMessage.addListener(this.handleDataUpdate);
         chrome.runtime.sendMessage({ type: "query_livedata", tabId });
     },
@@ -255,10 +254,7 @@ export default {
             return command;
         },
         noKey(chunkList) {
-            return (
-                needKeySites.some((site) => this.currentUrlHost.includes(site)) &&
-                (this.status.missingKey || ("keyUrl" in chunkList && !("keyIndex" in chunkList)))
-            );
+            return this.status.missingKey || "keyUrl" in chunkList && !("keyIndex" in chunkList);
         },
         copy(chunkList) {
             const input = this.$refs[chunkList.url];


### PR DESCRIPTION
在后台进行正确修复（已加入注释），同时让 Service Worker 唤醒后对支持站点（但未注入成功）的状态保持和 Service Worker 被杀死前的显示一样，以及两处忘记提前跳出循环的疏忽。

一个小问题：之前为什么要在串联赋值的后边加上括号？这不是 == 啊（我用这种语法确实不太符合某些语言的规范，本意只是想后面少打几个字）