### PR TITLE
 401 Unauthorized on OPENREC.tv

### DIFF
--- a/src/definitions/index.js
+++ b/src/definitions/index.js
@@ -35,6 +35,9 @@ export const needKeySites = [
     "pizzaradio.jp",
 ];
 export const siteAdditionalHeaders = {
+    "www.openrec.tv": {
+        Referer: "https://www.openrec.tv/"
+    },
     "www.onsen.ag": {
         Referer: "https://www.onsen.ag/"
     },


### PR DESCRIPTION
A minor change in OPENREC.tv has caused it to return 401, so a referer is now required.
I checked and it works fine with this option.
--headers "Referer: https://www.openrec.tv/"