### PR TITLE
(PoC) support new niconico(eR) video, refactor key management

### DIFF
--- a/assets/scripts/inject_core.js
+++ b/assets/scripts/inject_core.js
@@ -14,16 +14,6 @@
         },
         false
     );
-    let cookies = {};
-    window.addEventListener(
-        "MinyamiPageCookies",
-        (event) => {
-            for (const { name, value } of event.detail) {
-                cookies[name] = `${name}=${value};`;
-            }
-        },
-        false
-    );
     window.addEventListener("unload", notify({ type: "page_url", url: window.location.href }), false);
     const escapeFilename = (filename) => {
         return filename.replace(/[\/\*\\\:|\?<>"!]/gi, "_");
@@ -154,11 +144,11 @@
                         break;
                     }
                     case "www.nicovideo.jp": {
-                        const { domand_bid } = cookies;
-                        if (!domand_bid) break;
+                        const cookies = document.cookie.match(/(domand_bid\=.+?)(;|$)/)[1];
+                        if (!cookies) break;
                         notify({
                             type: "cookies",
-                            cookies: domand_bid
+                            cookies
                         });
                         break;
                     }
@@ -277,10 +267,10 @@
         notify({
             type: "cookies",
             cookies: [
-                cookies["CloudFront-Policy"],
-                cookies["CloudFront-Signature"],
-                cookies["CloudFront-Key-Pair-Id"]
-            ].join(" ")
+                document.cookie.match(/(CloudFront-Policy\=.+?)(;|$)/)[1],
+                document.cookie.match(/(CloudFront-Signature\=.+?)(;|$)/)[1],
+                document.cookie.match(/(CloudFront-Key-Pair-Id\=.+?)(;|$)/)[1],
+            ].join("; ")
         });
     };
 
@@ -295,7 +285,7 @@
                 .join("");
             notify({
                 type: "cookies",
-                cookies: "licenseUID=" + document.cookie.match(/licenseUID\=(.+?)(;|$)/)[1]
+                cookies: document.cookie.match(/(licenseUID\=.+?)(;|$)/)[1]
             });
             notify({
                 type: "key",
@@ -308,7 +298,7 @@
     const ch360 = (xhr) => {
         notify({
             type: "cookies",
-            cookies: "ch360pt=" + document.cookie.match(/ch360pt\=(.+?)(;|$)/)[1]
+            cookies: document.cookie.match(/(ch360pt\=.+?)(;|$)/)[1]
         });
     };
 
@@ -352,7 +342,7 @@
         }
         notify({
             type: "cookies",
-            cookies: "PREF=" + document.cookie.match(/PREF\=(.+?)(;|$)/)[1]
+            cookies: document.cookie.match(/(PREF\=.+?)(;|$)/)[1]
         });
     };
 

--- a/assets/scripts/inject_core.js
+++ b/assets/scripts/inject_core.js
@@ -18,16 +18,6 @@
     const escapeFilename = (filename) => {
         return filename.replace(/[\/\*\\\:|\?<>"!]/gi, "_");
     };
-    const getFileExt = (m3u8Content) => {
-        switch (m3u8Content.match(/#EXT-X-MAP:URI=".*\.(\w+)(\?|")/m)?.[1]) {
-            case "cmfv":
-                return "m4v.ts";
-            case "cmfa":
-                return "m4a.ts";
-            default:
-                return "ts";
-        }
-    };
     let key = "";
     if (window.fetch) {
         const _fetch = fetch;
@@ -61,14 +51,11 @@
                                     streamName
                                 });
                             } else {
-                                const keyUrlMatch = responseText.match(/#EXT-X-KEY:.*URI="(abematv-license:|https:.*).*?"/);
                                 notify({
                                     type: "chunklist",
-                                    fileExt: getFileExt(responseText),
                                     content: responseText,
                                     url: r.url,
-                                    title,
-                                    ...(keyUrlMatch && { keyUrl: keyUrlMatch[1] })
+                                    title
                                 });
                             }
                             switch (location.host) {
@@ -124,16 +111,11 @@
                         title: title || escapeFilename(document.title)
                     });
                 } else {
-                    const keyUrlMatch = ["live.nicovideo.jp", "live2.nicovideo.jp"].includes(location.host) ?
-                        [, `nicolive://${this.responseURL.match(/ht2_nicolive=(\d+)/)[1]}`] :
-                        this.responseText.match(/#EXT-X-KEY:.*URI="(.*)"/);
                     notify({
                         type: "chunklist",
-                        fileExt: getFileExt(this.responseText),
                         content: this.responseText,
                         url: this.responseURL,
-                        title: title || escapeFilename(document.title),
-                        ...(keyUrlMatch && { keyUrl: keyUrlMatch[1] })
+                        title: title || escapeFilename(document.title)
                     });
                 }
                 // Execute after m3u8 loads
@@ -258,7 +240,7 @@
             notify({
                 type: "key",
                 key: key,
-                url: `nicolive://${key.match(/^\d+_(\d+)/)[1]}`
+                url: `nicolive://${key.match(/^(\d+)_/)[1]}`
             });
         } catch {}
     };

--- a/assets/scripts/inject_core.js
+++ b/assets/scripts/inject_core.js
@@ -156,10 +156,6 @@
                     ch360(this);
                     break;
                 }
-                case "www.nicovideo.jp": {
-                    matchurl(this);
-                    break;
-                }
                 case "hibiki-radio.jp": {
                     matchurl(this, "datakey");
                     break;

--- a/manifest.json
+++ b/manifest.json
@@ -14,19 +14,16 @@
     "icons": {
         "128": "assets/logo.png"
     },
-    "permissions": ["tabs", "scripting", "storage"],
+    "permissions": ["cookies", "tabs", "scripting", "storage"],
     "host_permissions": [
         "https://www.openrec.tv/*",
         "https://abema.tv/channels/*/slots/*",
         "https://abema.tv/video/*",
         "https://abema.tv/payperview/*",
-        "https://live2.nicovideo.jp/watch/*",
-        "https://live.nicovideo.jp/watch/*",
         "https://www.dmm.com/digital/-/player/*",
         "https://www.dmm.com/monthly/-/player/*",
         "https://www.dmm.co.jp/digital/-/player/*",
         "https://www.dmm.co.jp/monthly/-/player/*",
-        "https://www.360ch.tv/video/view/*",
         "https://www.sonymusic.co.jp/*",
         "https://twitcasting.tv/*",
         "https://www.showroom-live.com/*",
@@ -34,14 +31,16 @@
         "https://www.onsen.ag/*",
         "https://www.youtube.com/*",
         "https://nogidoga.com/episode/*",
-        "https://spwn.jp/*",
         "https://stagecrowd.live/*",
         "https://live.bilibili.com/*",
         "https://mixbox.live/campaign_live/*",
         "https://playervspf.channel.or.jp/*",
         "https://nicochannel.jp/*",
         "https://pizzaradio.jp/*",
-        "https://gs-ch.com/*"
+        "https://gs-ch.com/*",
+        "*://*.360ch.tv/*",
+        "*://*.nicovideo.jp/*",
+        "*://spwn.jp/*"
     ],
     "content_scripts": [
         {
@@ -57,6 +56,7 @@
                 "https://www.dmm.co.jp/digital/-/player/*",
                 "https://www.dmm.co.jp/monthly/-/player/*",
                 "https://www.360ch.tv/video/view/*",
+                "https://www.nicovideo.jp/watch/*",
                 "https://www.sonymusic.co.jp/*",
                 "https://twitcasting.tv/*",
                 "https://www.showroom-live.com/*",
@@ -95,6 +95,7 @@
             "https://www.dmm.com/monthly/-/player/*",
             "https://www.dmm.co.jp/digital/-/player/*",
             "https://www.dmm.co.jp/monthly/-/player/*",
+            "https://www.nicovideo.jp/watch/*",
             "https://www.360ch.tv/video/view/*",
             "https://www.sonymusic.co.jp/*",
             "https://twitcasting.tv/*",

--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,7 @@
         "https://www.onsen.ag/*",
         "https://www.youtube.com/*",
         "https://nogidoga.com/episode/*",
+        "https://spwn.jp/*",
         "https://stagecrowd.live/*",
         "https://live.bilibili.com/*",
         "https://mixbox.live/campaign_live/*",
@@ -38,9 +39,8 @@
         "https://nicochannel.jp/*",
         "https://pizzaradio.jp/*",
         "https://gs-ch.com/*",
-        "*://*.360ch.tv/*",
-        "*://*.nicovideo.jp/*",
-        "*://spwn.jp/*"
+        "https://*.360ch.tv/*",
+        "https://*.nicovideo.jp/*"
     ],
     "content_scripts": [
         {

--- a/src/core/m3u8.js
+++ b/src/core/m3u8.js
@@ -15,6 +15,7 @@ export class Playlist {
         lines.forEach((line, index) => {
             if (line.startsWith("#EXT-X-STREAM-INF")) {
                 const chunkList = {
+                    fileExt: "ts",
                     type: "video"
                 };
                 if (line.match(/BANDWIDTH=(\d+)/) !== null) {

--- a/src/core/m3u8.js
+++ b/src/core/m3u8.js
@@ -1,4 +1,8 @@
 import CommonUtils from "./utils/common";
+const FILE_EXTS = {
+    cmfv: "m4v.ts",
+    cmfa: "m4a.ts",
+};
 export class Chunklist {
     constructor(type) {
         this.type = type;
@@ -6,13 +10,11 @@ export class Chunklist {
         this.parsed = false;
     }
     set content(value) {
-        switch (value.match(/#EXT-X-MAP:URI=".*\.(\w+)(\?|")/m)?.[1]) {
-            case "cmfv":
-                this.fileExt = "m4v.ts";
-            case "cmfa":
-                this.fileExt = "m4a.ts";
-        };
-        if (this.keyUrl) return this.parsed = true;
+        const extMatch = value.match(/#EXT-X-MAP:URI=".*\.(\w+)(\?|")/m);
+        if (extMatch && extMatch[1] in FILE_EXTS) {
+            this.fileExt = FILE_EXTS[extMatch[1]];
+        }
+        if ("keyUrl" in this) return this.parsed = true;
         const keyUrlMatch = value.match(/#EXT-X-KEY:.*URI="(abematv-license:|https:.*).*?"/);
         if (keyUrlMatch) {
             this.keyUrl = keyUrlMatch[1];
@@ -20,7 +22,6 @@ export class Chunklist {
         this.parsed = true;
     }
 }
-
 export class Playlist {
     constructor({ content, url, title = "", streamName, disableAutoParse = false }) {
         this.content = content;

--- a/src/core/m3u8.js
+++ b/src/core/m3u8.js
@@ -1,4 +1,26 @@
 import CommonUtils from "./utils/common";
+export class Chunklist {
+    constructor(type) {
+        this.type = type;
+        this.fileExt = "ts";
+        this.parsed = false;
+    }
+    set content(value) {
+        switch (value.match(/#EXT-X-MAP:URI=".*\.(\w+)(\?|")/m)?.[1]) {
+            case "cmfv":
+                this.fileExt = "m4v.ts";
+            case "cmfa":
+                this.fileExt = "m4a.ts";
+        };
+        if (this.keyUrl) return this.parsed = true;
+        const keyUrlMatch = value.match(/#EXT-X-KEY:.*URI="(abematv-license:|https:.*).*?"/);
+        if (keyUrlMatch) {
+            this.keyUrl = keyUrlMatch[1];
+        }
+        this.parsed = true;
+    }
+}
+
 export class Playlist {
     constructor({ content, url, title = "", streamName, disableAutoParse = false }) {
         this.content = content;
@@ -14,10 +36,7 @@ export class Playlist {
         const lines = this.content.split("\n");
         lines.forEach((line, index) => {
             if (line.startsWith("#EXT-X-STREAM-INF")) {
-                const chunkList = {
-                    fileExt: "ts",
-                    type: "video"
-                };
+                const chunkList = new Chunklist("video");
                 if (line.match(/BANDWIDTH=(\d+)/) !== null) {
                     chunkList.bandwidth = line.match(/BANDWIDTH=(\d+)/)[1];
                 }
@@ -27,13 +46,13 @@ export class Playlist {
                         y: line.match(/RESOLUTION=(.+?)(\n|$|\,)/)[1].split("x")[1]
                     };
                 }
+                if (this.url.includes("nicolive")) {
+                    chunkList.keyUrl = `nicolive://${this.url.match(/nicolive-production-pg(\d+)/)[1]}`;
+                };
                 chunkList.url = CommonUtils.buildFullUrl(this.url, lines[index + 1]);
                 this.chunkLists.push(chunkList);
-            }
-            if (line.startsWith("#EXT-X-MEDIA:TYPE=AUDIO")) {
-                const chunkList = {
-                    type: "audio"
-                };
+            } else if (line.startsWith("#EXT-X-MEDIA:TYPE=AUDIO")) {
+                const chunkList = new Chunklist("audio");
                 chunkList.url = CommonUtils.buildFullUrl(this.url, line.match(/URI="(.+?)"/)[1]);
                 chunkList.name = line.match(/NAME="(.+?)"/) && line.match(/NAME="(.+?)"/)[1];
                 this.chunkLists.push(chunkList);

--- a/src/definitions/index.js
+++ b/src/definitions/index.js
@@ -31,7 +31,6 @@ export const supportedSites = [
 ];
 export const needCookiesSites = [
     new NeedCookiesSite("(www).360ch.tv"),
-    new NeedCookiesSite("spwn.jp"),
     new NeedCookiesSite("(www).nicovideo.jp")
 ];
 export const needKeySites = [

--- a/src/definitions/index.js
+++ b/src/definitions/index.js
@@ -68,7 +68,7 @@ export const minyamiVersionRequirementMap = {
     "nicochannel.jp": "4.4.13",
     "pizzaradio.jp": "4.4.13",
     "gs-ch.com": "4.4.13",
-    "www.nicovideo.jp": "5.2.1",
+    "www.nicovideo.jp": "5.3.0",
 };
 export const statusFlags = {
     supported: 0b1,

--- a/src/definitions/index.js
+++ b/src/definitions/index.js
@@ -37,7 +37,6 @@ export const needKeySites = [
     "abema.tv",
     "live2.nicovideo.jp",
     "live.nicovideo.jp",
-    "www.nicovideo.jp",
     "dmm.com",
     "dmm.co.jp",
     "hibiki-radio.jp",

--- a/src/definitions/index.js
+++ b/src/definitions/index.js
@@ -1,9 +1,16 @@
+class NeedCookiesSite {
+    constructor(url) {
+        this.cookieDomain = url.replace(/\(.*\)/, "");
+        this.domain = url.replace(/\(|\)/g, "");
+    }
+}
 export const supportedSites = [
     "www.openrec.tv",
     "abema.tv",
     "live2.nicovideo.jp",
     "live.nicovideo.jp",
     "cas.nicovideo.jp",
+    "www.nicovideo.jp",
     "www.dmm.com",
     "www.dmm.co.jp",
     "www.360ch.tv",
@@ -22,11 +29,16 @@ export const supportedSites = [
     "pizzaradio.jp",
     "gs-ch.com",
 ];
-export const needCookiesSites = ["360ch.tv"];
+export const needCookiesSites = [
+    new NeedCookiesSite("(www).360ch.tv"),
+    new NeedCookiesSite("spwn.jp"),
+    new NeedCookiesSite("(www).nicovideo.jp")
+];
 export const needKeySites = [
     "abema.tv",
     "live2.nicovideo.jp",
     "live.nicovideo.jp",
+    "www.nicovideo.jp",
     "dmm.com",
     "dmm.co.jp",
     "hibiki-radio.jp",
@@ -57,9 +69,11 @@ export const minyamiVersionRequirementMap = {
     "nicochannel.jp": "4.4.13",
     "pizzaradio.jp": "4.4.13",
     "gs-ch.com": "4.4.13",
+    "www.nicovideo.jp": "5.2.1",
 };
 export const statusFlags = {
     supported: 0b1,
+    allReady: 0b1,
     missingCookie: 0b10,
     missingKey: 0b100,
 };

--- a/src/pages/background/index.js
+++ b/src/pages/background/index.js
@@ -33,8 +33,10 @@ const getCachedTabUrl = async (tabId) => {
         tabToUrl[tabId] = url;
         for (const site of needCookiesSites) {
             if (url.includes(site.domain)) {
-                evalOnTab(tabId, (detail) => {
-                    window.dispatchEvent(new CustomEvent("MinyamiPageCookies", { detail }));
+                evalOnTab(tabId, (cookies) => {
+                    for (const { name, value } of cookies) {
+                        document.cookie = `${name}=${value}`;
+                    }
                 }, await chrome.cookies.getAll({ domain: site.cookieDomain }));
                 break;
             }
@@ -77,7 +79,6 @@ const handleContentScriptMessage = async (message, sender) => {
         });
         if (url.includes("abema.tv")) {
             for (const chunklist of playlist.chunkLists) {
-                chunklist.fileExt = "ts";
                 chunklist.keyUrl = "abematv-license:";
             }
         }

--- a/src/pages/config/index.vue
+++ b/src/pages/config/index.vue
@@ -228,12 +228,12 @@ export default {
             const prefix = this.configForm.useNPX ? "npx minyami" : "minyami";
             let command = "";
             if (!this.form.recoverMode) {
-                command += `${prefix} -d "${chunklist.url}" --output "${playlist.title.replace(/\"/g, `\\"`)}.ts"`;
+                command += `${prefix} -d "${chunklist.url}" --output "${playlist.title.replace(/\"/g, `\\"`)}.${chunklist.fileExt}"`;
             } else {
                 command += `${prefix} -r "${chunklist.url}"`;
             }
-            if ("keyIndex" in chunklist) {
-                command += ` --key "${this.keys[chunklist.keyIndex]}"`;
+            if ("keyUrl" in chunklist && chunklist.keyUrl in this.keys) {
+                command += ` --key "${this.keys[chunklist.keyUrl]}"`;
             }
             if (this.cookies.length > 0) {
                 command += ` --headers "Cookie: ${this.cookies[index] || this.cookies[0]}"`;
@@ -254,7 +254,7 @@ export default {
             return command;
         },
         noKey(chunkList) {
-            return this.status.missingKey || ("keyUrl" in chunkList && !("keyIndex" in chunkList));
+            return this.status.missingKey || ("keyUrl" in chunkList && !(chunkList.keyUrl in this.keys));
         },
         copy(chunkList) {
             const input = this.$refs[chunkList.url];

--- a/src/pages/config/index.vue
+++ b/src/pages/config/index.vue
@@ -254,7 +254,7 @@ export default {
             return command;
         },
         noKey(chunkList) {
-            return this.status.missingKey || ("keyUrl" in chunkList && !(chunkList.keyUrl in this.keys));
+            return this.status.missingKey || (chunkList.keyUrl && !(chunkList.keyUrl in this.keys));
         },
         copy(chunkList) {
             const input = this.$refs[chunkList.url];


### PR DESCRIPTION
因为最新的 NicoNico 动画 (eR) 修改了传输方式，不少群友需要个方便的手段下载，想了半天还是觉得用这个轮子方便一些。

为此有几个重大改变：

1. 重构 key 索引为字典形式（存储时依旧使用数组，但 API 使用 `Object.fromEntries()` 方便直接匹配获得的流）。目前为此在 service worker 部分专门为 AbemaTV 做了处理，可能对 #43 有一定帮助。
2. 添加支持 .m4a 和 m4v 的规则（免封装），将来可能会对其他 fMP4 类的流提供支持（目前我先胡写了一个“需要 5.2.1 或更高”，但目前保留了 .ts 扩展名，所以用是可以用的，只不过合成出来的东西不是真的 MPEG-TS 就是）。可能的话最好设计一个优雅的流程去 Minyami 主程序后期输出。
3. XHR 请求的 cookies 从 service worker 直接调用 `chrome.cookies` API 获得并通过消息传送到注入脚本中缓存，因为关键值通过 `document.cookie` 获取不到，也没有其他办法读取。为此扩展了声明文件中目标站域的的访问权限（`*://*.<hostname>/*`)，还写了个简单的语法糖用来同时定义 FQDN 和二级域名匹配（因为一级域名需要借助外部包才能精确定义，不能直接用正则表达式等方式简单支持）。

目前 PR 属于可供测试的状态，首要目的是先给群友弄一个能用的东西出来，然后再考虑 mergeability。当然已经考虑了一些整体改进，也测试了不少改动涉及到的情况，但显然还需要更多测试。